### PR TITLE
Add homepage field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "isomorphic-gatty",
   "version": "2.1.0",
   "description": "An append-only event log for multi-device local-first apps, built on isomorphic-git",
+  "repository": "https://github.com/fasiha/isomorphic-gatty",
   "main": "index.js",
   "scripts": {
     "test": "tape test-*js",


### PR DESCRIPTION
I had a hard time reaching this repo as it doesn't have the homepage or repo fields set. I've added the repo field so that npm / yarn will provide a link here.

Thanks for this package btw, just looking into it, but it seems very interesting. I'm thinking to combine it with git-remote-encrypted (which I just released a very early prototype of) to create an offline-first and encrypted storage mechanism...